### PR TITLE
Fix combinations of apply and some funcs that take numeric arguments

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -638,11 +638,11 @@ do_div(ENV *env, NODE *alist) {
 static NODE*
 do_plus1(ENV *env, NODE *alist) {
   NODE *x, *c;
+  UNUSED(env);
 
   if (node_narg(alist) != 1) return new_errorn("malformed 1+", alist);
 
-  x = eval_node(env, alist->car);
-  if (x->t == NODE_ERROR) return x;
+  x = alist->car;
 
   c = new_node();
   c->t = x->t;
@@ -651,7 +651,6 @@ do_plus1(ENV *env, NODE *alist) {
   case NODE_DOUBLE: c->d = x->d + 1.0; break;
   default: free_node(c); c = new_error("malformed number"); break;
   }
-  free_node(x);
   return c;
 }
 
@@ -2125,7 +2124,7 @@ add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "+", do_plus);
   add_sym(env, NODE_BUILTINFUNC, "-", do_minus);
   add_sym(env, NODE_BUILTINFUNC, "/", do_div);
-  add_sym(env, NODE_SPECIAL    , "1+", do_plus1);
+  add_sym(env, NODE_BUILTINFUNC, "1+", do_plus1);
   add_sym(env, NODE_SPECIAL    , "1-", do_minus1);
   add_sym(env, NODE_BUILTINFUNC, "<", do_lt);
   add_sym(env, NODE_BUILTINFUNC, "<=", do_le);

--- a/cisp.c
+++ b/cisp.c
@@ -488,11 +488,7 @@ do_plus(ENV *env, NODE *alist) {
   nn->i = 0;
 
   while (!node_isnull(alist)) {
-    c = eval_node(env, alist->car);
-    if (c->t == NODE_ERROR) {
-      free_node(nn);
-      return c;
-    }
+    c = alist->car;
     if (nn->t == NODE_INT) {
       if (c->t == NODE_DOUBLE) {
         nn->d = double_value(env, nn, &err) + double_value(env, c, &err);
@@ -502,7 +498,6 @@ do_plus(ENV *env, NODE *alist) {
     } else {
       nn->d += double_value(env, c, &err);
     }
-    free_node(c);
     if (err) {
       free_node(nn);
       return err;
@@ -2137,7 +2132,7 @@ static void
 add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "%", do_mod);
   add_sym(env, NODE_SPECIAL    , "*", do_mul);
-  add_sym(env, NODE_SPECIAL    , "+", do_plus);
+  add_sym(env, NODE_BUILTINFUNC, "+", do_plus);
   add_sym(env, NODE_SPECIAL    , "-", do_minus);
   add_sym(env, NODE_SPECIAL    , "/", do_div);
   add_sym(env, NODE_SPECIAL    , "1+", do_plus1);

--- a/cisp.c
+++ b/cisp.c
@@ -566,8 +566,7 @@ do_mul(ENV *env, NODE *alist) {
   nn->i = 1;
 
   while (!node_isnull(alist)) {
-    c = eval_node(env, alist->car);
-    if (c->t == NODE_ERROR) return c;
+    c = alist->car;
     if (nn->t == NODE_INT) {
       if (c->t == NODE_DOUBLE) {
         nn->d = double_value(env, nn, &err) * double_value(env, c, &err);
@@ -577,7 +576,6 @@ do_mul(ENV *env, NODE *alist) {
     } else {
       nn->d *= double_value(env, c, &err);
     }
-    free_node(c);
     if (err) {
       free_node(nn);
       return err;
@@ -2127,7 +2125,7 @@ sort_syms(ENV *env) {
 static void
 add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "%", do_mod);
-  add_sym(env, NODE_SPECIAL    , "*", do_mul);
+  add_sym(env, NODE_BUILTINFUNC, "*", do_mul);
   add_sym(env, NODE_BUILTINFUNC, "+", do_plus);
   add_sym(env, NODE_BUILTINFUNC, "-", do_minus);
   add_sym(env, NODE_SPECIAL    , "/", do_div);

--- a/cisp.c
+++ b/cisp.c
@@ -591,8 +591,7 @@ do_div(ENV *env, NODE *alist) {
 
   if (node_narg(alist) < 1) return new_errorn("malformed /", alist);
 
-  c = eval_node(env, alist->car);
-  if (c->t == NODE_ERROR) return c;
+  c = alist->car;
   nn = new_node();
   nn->t = c->t;
   switch (nn->t) {
@@ -606,7 +605,6 @@ do_div(ENV *env, NODE *alist) {
     free_node(nn);
     return new_error("malformed number");
   }
-  free_node(c);
 
   alist = alist->cdr;
   if (node_isnull(alist)) {
@@ -618,8 +616,7 @@ do_div(ENV *env, NODE *alist) {
   }
 
   while (!node_isnull(alist)) {
-    c = eval_node(env, alist->car);
-    if (c->t == NODE_ERROR) return c;
+    c = alist->car;
     if (nn->t == NODE_INT) {
       if (c->t == NODE_DOUBLE) {
         nn->d = double_value(env, nn, &err) / double_value(env, c, &err);
@@ -629,7 +626,6 @@ do_div(ENV *env, NODE *alist) {
     } else {
       nn->d /= double_value(env, c, &err);
     }
-    free_node(c);
     if (err) {
       free_node(nn);
       return err;
@@ -2128,7 +2124,7 @@ add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "*", do_mul);
   add_sym(env, NODE_BUILTINFUNC, "+", do_plus);
   add_sym(env, NODE_BUILTINFUNC, "-", do_minus);
-  add_sym(env, NODE_SPECIAL    , "/", do_div);
+  add_sym(env, NODE_BUILTINFUNC, "/", do_div);
   add_sym(env, NODE_SPECIAL    , "1+", do_plus1);
   add_sym(env, NODE_SPECIAL    , "1-", do_minus1);
   add_sym(env, NODE_BUILTINFUNC, "<", do_lt);

--- a/cisp.c
+++ b/cisp.c
@@ -657,11 +657,11 @@ do_plus1(ENV *env, NODE *alist) {
 static NODE*
 do_minus1(ENV *env, NODE *alist) {
   NODE *x, *c;
+  UNUSED(env);
 
   if (node_narg(alist) != 1) return new_errorn("malformed 1-", alist);
 
-  x = eval_node(env, alist->car);
-  if (x->t == NODE_ERROR) return x;
+  x = alist->car;
 
   c = new_node();
   c->t = x->t;
@@ -670,7 +670,6 @@ do_minus1(ENV *env, NODE *alist) {
   case NODE_DOUBLE: c->d = x->d - 1.0; break;
   default: free_node(c); c = new_error("malformed number"); break;
   }
-  free_node(x);
   return c;
 }
 
@@ -2125,7 +2124,7 @@ add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "-", do_minus);
   add_sym(env, NODE_BUILTINFUNC, "/", do_div);
   add_sym(env, NODE_BUILTINFUNC, "1+", do_plus1);
-  add_sym(env, NODE_SPECIAL    , "1-", do_minus1);
+  add_sym(env, NODE_BUILTINFUNC, "1-", do_minus1);
   add_sym(env, NODE_BUILTINFUNC, "<", do_lt);
   add_sym(env, NODE_BUILTINFUNC, "<=", do_le);
   add_sym(env, NODE_SPECIAL    , "=", do_eq);

--- a/cisp.c
+++ b/cisp.c
@@ -513,8 +513,7 @@ do_minus(ENV *env, NODE *alist) {
 
   if (node_narg(alist) < 1) return new_errorn("malformed -", alist);
 
-  c = eval_node(env, alist->car);
-  if (c->t == NODE_ERROR) return c;
+  c = alist->car;
   nn = new_node();
   nn->t = c->t;
   switch (nn->t) {
@@ -528,7 +527,6 @@ do_minus(ENV *env, NODE *alist) {
     free_node(nn);
     return new_error("malformed number");
   }
-  free_node(c);
 
   alist = alist->cdr;
   if (node_isnull(alist)) {
@@ -540,8 +538,7 @@ do_minus(ENV *env, NODE *alist) {
   }
 
   while (!node_isnull(alist)) {
-    c = eval_node(env, alist->car);
-    if (c->t == NODE_ERROR) return c;
+    c = alist->car;
     if (nn->t == NODE_INT) {
       if (c->t == NODE_DOUBLE) {
         nn->d = double_value(env, nn, &err) - double_value(env, c, &err);
@@ -551,7 +548,6 @@ do_minus(ENV *env, NODE *alist) {
     } else {
       nn->d -= double_value(env, c, &err);
     }
-    free_node(c);
     if (err) {
       free_node(nn);
       return err;
@@ -2133,7 +2129,7 @@ add_defaults(ENV *env) {
   add_sym(env, NODE_BUILTINFUNC, "%", do_mod);
   add_sym(env, NODE_SPECIAL    , "*", do_mul);
   add_sym(env, NODE_BUILTINFUNC, "+", do_plus);
-  add_sym(env, NODE_SPECIAL    , "-", do_minus);
+  add_sym(env, NODE_BUILTINFUNC, "-", do_minus);
   add_sym(env, NODE_SPECIAL    , "/", do_div);
   add_sym(env, NODE_SPECIAL    , "1+", do_plus1);
   add_sym(env, NODE_SPECIAL    , "1-", do_minus1);


### PR DESCRIPTION
Fix combinations of `apply` and funcs below.

```
+
-
*
/
1+
1-
```

Ex.

```
(apply '+ '((+ 1 2) (+ 3 4))) ; should cause an error
```
