### PR TITLE
Fix if to treat any non-nil value as true

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -1289,26 +1289,10 @@ static NODE *do_if(ENV *env, NODE *alist) {
   c = eval_node(env, alist->car);
   if (c->t == NODE_ERROR)
     return c;
-  switch (c->t) {
-  case NODE_NIL:
-    r = 0;
-    break;
-  case NODE_T:
-    r = 1;
-    break;
-  case NODE_INT:
-    r = c->i;
-    break;
-  case NODE_DOUBLE:
-    r = (long)c->d;
-    break;
-  default:
-    r = 1;
-    break;
-  }
+  r = !node_isnull(c);
   free_node(c);
   if (!has_else) {
-    if (r > 0) {
+    if (r) {
       NODE *tail = new_node();
       tail->t = NODE_TAIL;
       tail->car = alist->cdr->car;
@@ -1320,7 +1304,7 @@ static NODE *do_if(ENV *env, NODE *alist) {
   {
     NODE *tail = new_node();
     tail->t = NODE_TAIL;
-    tail->car = r > 0 ? alist->cdr->car : alist->cdr->cdr->car;
+    tail->car = r ? alist->cdr->car : alist->cdr->cdr->car;
     tail->cdr = NULL;
     return tail;
   }

--- a/t/76-if-truthiness.lisp
+++ b/t/76-if-truthiness.lisp
@@ -1,0 +1,8 @@
+(println (if 0 'a 'b))
+(println (if -1 'a 'b))
+(println (if 0.0 'a 'b))
+(println (if "" 'a 'b))
+(println (if nil 'a 'b))
+(println (if '() 'a 'b))
+(if -1 (println 'yes))
+(if 0 (println 'zero-is-true))

--- a/t/76-if-truthiness.out
+++ b/t/76-if-truthiness.out
@@ -1,0 +1,8 @@
+a
+a
+a
+a
+b
+b
+yes
+zero-is-true


### PR DESCRIPTION
`do_if` converted the condition to an integer and branched on `r > 0`, so `(if 0 'a 'b)` and `(if -1 'a 'b)` both took the else branch. In Lisp everything except `nil` is true, and `cond` in the same interpreter already follows that rule. Branch on `node_isnull` instead. Add a regression test.