### PR TITLE
Fix and with no arguments to return t

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -1084,7 +1084,9 @@ static NODE *do_and(ENV *env, NODE *alist) {
   }
   if (c)
     return c;
-  return new_node();
+  c = new_node();
+  c->t = NODE_T;
+  return c;
 }
 
 static NODE *do_or(ENV *env, NODE *alist) {

--- a/t/77-and-or.lisp
+++ b/t/77-and-or.lisp
@@ -1,0 +1,6 @@
+(println (and))
+(println (or))
+(println (and 1 2))
+(println (and 1 nil 2))
+(println (or nil 3))
+(println (or nil nil))

--- a/t/77-and-or.out
+++ b/t/77-and-or.out
@@ -1,0 +1,6 @@
+t
+nil
+2
+nil
+3
+nil


### PR DESCRIPTION
`(and)` returned `nil`; Common Lisp defines it as `t` (identity of conjunction). Add a regression test covering `and`/`or` basics.