### PR TITLE
Fix = mixed int/float and character comparison

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -1489,12 +1489,18 @@ static NODE *do_eq(ENV *env, NODE *alist) {
   nn = new_node();
   switch (lhs->t) {
   case NODE_CHARACTER:
-    if (lhs->c == rhs->c) {
+    if (rhs->t != NODE_CHARACTER) {
+      err = new_error("illegal comparing");
+    } else if (lhs->c == rhs->c) {
       nn->t = NODE_T;
     }
     break;
   case NODE_INT:
-    if (int_value(env, lhs, &err) == int_value(env, rhs, &err)) {
+    if (rhs->t == NODE_DOUBLE) {
+      if (double_value(env, lhs, &err) == double_value(env, rhs, &err)) {
+        nn->t = NODE_T;
+      }
+    } else if (int_value(env, lhs, &err) == int_value(env, rhs, &err)) {
       nn->t = NODE_T;
     }
     break;

--- a/t/78-numeric-equal.lisp
+++ b/t/78-numeric-equal.lisp
@@ -1,0 +1,6 @@
+(println (= 1 1.9))
+(println (= 1.9 1))
+(println (= 1 1.0))
+(println (= 2 2))
+(println (= #\a #\a))
+(println (= #\a #\b))

--- a/t/78-numeric-equal.out
+++ b/t/78-numeric-equal.out
@@ -1,0 +1,6 @@
+nil
+nil
+t
+t
+t
+nil


### PR DESCRIPTION
With an integer on the left, `=` truncated the right operand, so `(= 1 1.9)` was `t` while `(= 1.9 1)` was `nil`. Compare as doubles when either side is a float. The character case also read the union member of whatever the right operand was, so `(= #\a 97)` was `t`; require both sides to be characters. Add a regression test.