### PR TITLE
Fix swapped newline and return character names

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -373,9 +373,11 @@ void print_node(BUFFER *buf, NODE *node, PRINT_MODE mode) {
   switch (node->t) {
   case NODE_CHARACTER:
     if (node->c == '\n')
-      buf_append(buf, "#\\return");
-    else if (node->c == '\r')
       buf_append(buf, "#\\newline");
+    else if (node->c == '\r')
+      buf_append(buf, "#\\return");
+    else if (node->c == ' ')
+      buf_append(buf, "#\\space");
     else if (node->c == '\t')
       buf_append(buf, "#\\tab");
     else if (node->c == '\x0c')

--- a/t/87-char-print.lisp
+++ b/t/87-char-print.lisp
@@ -1,0 +1,5 @@
+(println #\newline)
+(println #\return)
+(println #\space)
+(println #\tab)
+(println #\a)

--- a/t/87-char-print.out
+++ b/t/87-char-print.out
@@ -1,0 +1,5 @@
+#\newline
+#\return
+#\space
+#\tab
+#\a


### PR DESCRIPTION
`print_node` printed `'\n'` as `#\return` and `'\r'` as `#\newline`. Also print the space character as `#\space` so it round-trips through the reader (bare `#\ ` is not parseable). Add a regression test.