### PR TITLE
Report error when format runs out of arguments

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -2256,7 +2256,10 @@ static NODE *do_format(ENV *env, NODE *alist) {
         r = r == 0 ? 1 : r;
         for (i = 0; i < r; i++)
           buf_append(&buf, tmp);
-      } else if (n != NULL) {
+      } else if (node_isnull(n)) {
+        buf_free(&buf);
+        return new_errorn("malformed format", alist);
+      } else {
         // TODO:
         //   ~T: Tabulate
         //   ~P: Plural

--- a/t/94-format-missing-arg.err
+++ b/t/94-format-missing-arg.err
@@ -1,0 +1,1 @@
+cisp: malformed format: (t ~~d needs an argument: ~d)

--- a/t/94-format-missing-arg.lisp
+++ b/t/94-format-missing-arg.lisp
@@ -1,0 +1,1 @@
+(format t "~~d needs an argument: ~d")


### PR DESCRIPTION
A consuming directive like `~d` with no remaining argument was silently skipped, so `(format t "~d ~d" 1)` printed `1 ` and `(format t "~d")` printed nothing. Report a malformed-format error as CL does. Add a regression test.