### PR TITLE
Fix buffer leak in new_errorn

### DIFF
--- a/cisp.c
+++ b/cisp.c
@@ -241,6 +241,7 @@ static NODE *new_errorn(const char *msg, NODE *n) {
   buf_append(&buf, ": ");
   print_node(&buf, n, PRINT_DEFAULT);
   node = new_error(buf.ptr);
+  buf_free(&buf);
   return node;
 }
 


### PR DESCRIPTION
`new_errorn` built the error message in a heap BUFFER and passed it to `new_error`, which strdups it, but the buffer itself was never freed — every contextual error node leaked its message buffer (valgrind: definitely lost). Free the buffer after constructing the node.